### PR TITLE
refactor: Add context.Context parameter to all callback functions

### DIFF
--- a/api_auth_or_error_middleware.go
+++ b/api_auth_or_error_middleware.go
@@ -22,7 +22,7 @@ func (a Auth) ApiAuthOrErrorMiddleware(next http.Handler) http.Handler {
 			return
 		}
 
-		userID, err := a.funcUserFindByAuthToken(authToken, UserAuthOptions{
+		userID, err := a.funcUserFindByAuthToken(r.Context(), authToken, UserAuthOptions{
 			UserIp:    req.GetIP(r),
 			UserAgent: r.UserAgent(),
 		})

--- a/api_login.go
+++ b/api_login.go
@@ -50,12 +50,12 @@ func (a Auth) apiLoginPasswordless(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	emailContent := a.passwordlessFuncEmailTemplateLoginCode(email, verificationCode, UserAuthOptions{
+	emailContent := a.passwordlessFuncEmailTemplateLoginCode(r.Context(), email, verificationCode, UserAuthOptions{
 		UserIp:    req.GetIP(r),
 		UserAgent: r.UserAgent(),
 	})
 
-	errEmailSent := a.passwordlessFuncEmailSend(email, "Login Code", emailContent)
+	errEmailSent := a.passwordlessFuncEmailSend(r.Context(), email, "Login Code", emailContent)
 
 	if errEmailSent != nil {
 		log.Println(errEmailSent)
@@ -75,7 +75,7 @@ func (a Auth) apiLoginUsernameAndPassword(w http.ResponseWriter, r *http.Request
 	email := req.GetStringTrimmed(r, "email")
 	password := req.GetStringTrimmed(r, "password")
 
-	response := a.LoginWithUsernameAndPassword(email, password, UserAuthOptions{
+	response := a.LoginWithUsernameAndPassword(r.Context(), email, password, UserAuthOptions{
 		UserIp:    req.GetIP(r),
 		UserAgent: r.UserAgent(),
 	})

--- a/api_login_code_verify.go
+++ b/api_login_code_verify.go
@@ -51,12 +51,12 @@ func (a Auth) authenticateViaUsername(w http.ResponseWriter, r *http.Request, us
 	var userID string
 	var errUser error
 	if a.passwordless {
-		userID, errUser = a.passwordlessFuncUserFindByEmail(username, UserAuthOptions{
+		userID, errUser = a.passwordlessFuncUserFindByEmail(r.Context(), username, UserAuthOptions{
 			UserIp:    req.GetIP(r),
 			UserAgent: r.UserAgent(),
 		})
 	} else {
-		userID, errUser = a.funcUserFindByUsername(username, firstName, lastName, UserAuthOptions{
+		userID, errUser = a.funcUserFindByUsername(r.Context(), username, firstName, lastName, UserAuthOptions{
 			UserIp:    req.GetIP(r),
 			UserAgent: r.UserAgent(),
 		})
@@ -79,7 +79,7 @@ func (a Auth) authenticateViaUsername(w http.ResponseWriter, r *http.Request, us
 		return
 	}
 
-	errSession := a.funcUserStoreAuthToken(token, userID, UserAuthOptions{
+	errSession := a.funcUserStoreAuthToken(r.Context(), token, userID, UserAuthOptions{
 		UserIp:    req.GetIP(r),
 		UserAgent: r.UserAgent(),
 	})

--- a/api_login_code_verify_test.go
+++ b/api_login_code_verify_test.go
@@ -1,6 +1,7 @@
 package auth
 
 import (
+	"context"
 	"errors"
 	"net/url"
 	"testing"
@@ -70,7 +71,7 @@ func TestApiLoginCodeVerifyAuthenticationError(t *testing.T) {
 		return "user@example.com", nil
 	}
 
-	authInstance.passwordlessFuncUserFindByEmail = func(email string, options UserAuthOptions) (userID string, err error) {
+	authInstance.passwordlessFuncUserFindByEmail = func(ctx context.Context, email string, options UserAuthOptions) (userID string, err error) {
 		return "", errors.New("db error")
 	}
 
@@ -91,7 +92,7 @@ func TestApiLoginCodeVerifyUserNotFound(t *testing.T) {
 		return "user@example.com", nil
 	}
 
-	authInstance.passwordlessFuncUserFindByEmail = func(email string, options UserAuthOptions) (userID string, err error) {
+	authInstance.passwordlessFuncUserFindByEmail = func(ctx context.Context, email string, options UserAuthOptions) (userID string, err error) {
 		return "", nil
 	}
 
@@ -112,11 +113,11 @@ func TestApiLoginCodeVerifyTokenStoreError(t *testing.T) {
 		return "user@example.com", nil
 	}
 
-	authInstance.passwordlessFuncUserFindByEmail = func(email string, options UserAuthOptions) (userID string, err error) {
+	authInstance.passwordlessFuncUserFindByEmail = func(ctx context.Context, email string, options UserAuthOptions) (userID string, err error) {
 		return "user123", nil
 	}
 
-	authInstance.funcUserStoreAuthToken = func(sessionID string, userID string, options UserAuthOptions) (err error) {
+	authInstance.funcUserStoreAuthToken = func(ctx context.Context, token string, userID string, options UserAuthOptions) error {
 		return errors.New("db error")
 	}
 
@@ -137,11 +138,11 @@ func TestApiLoginCodeVerifySuccess(t *testing.T) {
 		return "user@example.com", nil
 	}
 
-	authInstance.passwordlessFuncUserFindByEmail = func(email string, options UserAuthOptions) (userID string, err error) {
+	authInstance.passwordlessFuncUserFindByEmail = func(ctx context.Context, email string, options UserAuthOptions) (userID string, err error) {
 		return "user123", nil
 	}
 
-	authInstance.funcUserStoreAuthToken = func(sessionID string, userID string, options UserAuthOptions) (err error) {
+	authInstance.funcUserStoreAuthToken = func(ctx context.Context, token string, userID string, options UserAuthOptions) error {
 		return nil
 	}
 

--- a/api_login_test.go
+++ b/api_login_test.go
@@ -1,6 +1,7 @@
 package auth
 
 import (
+	"context"
 	"errors"
 	"net/http"
 	"net/url"
@@ -51,7 +52,7 @@ func TestApiLoginUsernameAndPasswordUserLoginError(t *testing.T) {
 	Nil(t, err)
 	NotNil(t, authInstance)
 
-	authInstance.funcUserLogin = func(username string, password string, options UserAuthOptions) (userID string, err error) {
+	authInstance.funcUserLogin = func(ctx context.Context, username string, password string, options UserAuthOptions) (userID string, err error) {
 		return "", errors.New("db error")
 	}
 
@@ -69,7 +70,7 @@ func TestApiLoginUsernameAndPasswordUserNotFound(t *testing.T) {
 	Nil(t, err)
 	NotNil(t, authInstance)
 
-	authInstance.funcUserLogin = func(username string, password string, options UserAuthOptions) (userID string, err error) {
+	authInstance.funcUserLogin = func(ctx context.Context, username string, password string, options UserAuthOptions) (userID string, err error) {
 		return "", nil
 	}
 
@@ -87,11 +88,11 @@ func TestApiLoginUsernameAndPasswordTokenStoreError(t *testing.T) {
 	Nil(t, err)
 	NotNil(t, authInstance)
 
-	authInstance.funcUserLogin = func(username string, password string, options UserAuthOptions) (userID string, err error) {
+	authInstance.funcUserLogin = func(ctx context.Context, username string, password string, options UserAuthOptions) (userID string, err error) {
 		return "user123", nil
 	}
 
-	authInstance.funcUserStoreAuthToken = func(sessionID string, userID string, options UserAuthOptions) (err error) {
+	authInstance.funcUserStoreAuthToken = func(ctx context.Context, token string, userID string, options UserAuthOptions) error {
 		return errors.New("db error")
 	}
 
@@ -109,7 +110,7 @@ func TestApiLoginUsernameAndPasswordSuccess(t *testing.T) {
 	Nil(t, err)
 	NotNil(t, authInstance)
 
-	authInstance.funcUserLogin = func(username string, password string, options UserAuthOptions) (userID string, err error) {
+	authInstance.funcUserLogin = func(ctx context.Context, username string, password string, options UserAuthOptions) (userID string, err error) {
 		return "user123", nil
 	}
 
@@ -196,7 +197,7 @@ func TestApiLoginPasswordlessEmailSendError(t *testing.T) {
 	Nil(t, err)
 	NotNil(t, authInstance)
 
-	authInstance.passwordlessFuncEmailSend = func(email string, emailSubject string, emailBody string) (err error) {
+	authInstance.passwordlessFuncEmailSend = func(ctx context.Context, email string, emailSubject string, emailBody string) (err error) {
 		return errors.New("smtp error")
 	}
 

--- a/api_logout.go
+++ b/api_logout.go
@@ -14,7 +14,7 @@ func (a Auth) apiLogout(w http.ResponseWriter, r *http.Request) {
 		api.Respond(w, r, api.Success("logout success"))
 	}
 
-	userID, errToken := a.funcUserFindByAuthToken(authToken, UserAuthOptions{
+	userID, errToken := a.funcUserFindByAuthToken(r.Context(), authToken, UserAuthOptions{
 		UserIp:    req.GetIP(r),
 		UserAgent: r.UserAgent(),
 	})
@@ -25,7 +25,7 @@ func (a Auth) apiLogout(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if userID != "" {
-		errLogout := a.funcUserLogout(userID, UserAuthOptions{
+		errLogout := a.funcUserLogout(r.Context(), userID, UserAuthOptions{
 			UserIp:    req.GetIP(r),
 			UserAgent: r.UserAgent(),
 		})

--- a/api_logout_test.go
+++ b/api_logout_test.go
@@ -1,6 +1,7 @@
 package auth
 
 import (
+	"context"
 	"errors"
 	"net/http"
 	"net/http/httptest"
@@ -28,7 +29,7 @@ func TestLogoutEndpointTokenValidationError(t *testing.T) {
 	NotNil(t, authInstance)
 
 	// Mock token validation error
-	authInstance.funcUserFindByAuthToken = func(token string, options UserAuthOptions) (userID string, err error) {
+	authInstance.funcUserFindByAuthToken = func(ctx context.Context, token string, options UserAuthOptions) (userID string, err error) {
 		return "", errors.New("db error")
 	}
 
@@ -57,7 +58,7 @@ func TestLogoutEndpointTokenValidationError_Custom(t *testing.T) {
 	authInstance, err := testSetupUsernameAndPasswordAuth()
 	Nil(t, err)
 
-	authInstance.funcUserFindByAuthToken = func(token string, options UserAuthOptions) (userID string, err error) {
+	authInstance.funcUserFindByAuthToken = func(ctx context.Context, token string, options UserAuthOptions) (userID string, err error) {
 		return "", errors.New("db error")
 	}
 

--- a/api_password_reset.go
+++ b/api_password_reset.go
@@ -50,7 +50,7 @@ func (a Auth) apiPasswordReset(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	errPasswordChange := a.funcUserPasswordChange(userID, password, UserAuthOptions{
+	errPasswordChange := a.funcUserPasswordChange(r.Context(), userID, password, UserAuthOptions{
 		UserIp:    req.GetIP(r),
 		UserAgent: r.UserAgent(),
 	})

--- a/api_password_reset_test.go
+++ b/api_password_reset_test.go
@@ -1,6 +1,7 @@
 package auth
 
 import (
+	"context"
 	"errors"
 	"net/http"
 	"net/url"
@@ -72,7 +73,7 @@ func TestPasswordResetEndpointPasswordChangeError(t *testing.T) {
 	}
 
 	// Mock password change error
-	authInstance.funcUserPasswordChange = func(username string, newPassword string, options UserAuthOptions) (err error) {
+	authInstance.funcUserPasswordChange = func(ctx context.Context, username string, newPassword string, options UserAuthOptions) (err error) {
 		return errors.New("db error")
 	}
 
@@ -95,7 +96,7 @@ func TestPasswordResetEndpointSuccess(t *testing.T) {
 	}
 
 	// Mock success
-	authInstance.funcUserPasswordChange = func(username string, newPassword string, options UserAuthOptions) (err error) {
+	authInstance.funcUserPasswordChange = func(ctx context.Context, username string, newPassword string, options UserAuthOptions) (err error) {
 		return nil
 	}
 

--- a/api_password_restore.go
+++ b/api_password_restore.go
@@ -34,7 +34,7 @@ func (a Auth) apiPasswordRestore(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	userID, err := a.funcUserFindByUsername(email, firstName, lastName, UserAuthOptions{
+	userID, err := a.funcUserFindByUsername(r.Context(), email, firstName, lastName, UserAuthOptions{
 		UserIp:    req.GetIP(r),
 		UserAgent: r.UserAgent(),
 	})
@@ -74,12 +74,12 @@ func (a Auth) apiPasswordRestore(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	emailContent := a.funcEmailTemplatePasswordRestore(userID, a.LinkPasswordReset(token), UserAuthOptions{
+	emailContent := a.funcEmailTemplatePasswordRestore(r.Context(), userID, a.LinkPasswordReset(token), UserAuthOptions{
 		UserIp:    req.GetIP(r),
 		UserAgent: r.UserAgent(),
 	})
 
-	errEmailSent := a.funcEmailSend(userID, "Password Restore", emailContent)
+	errEmailSent := a.funcEmailSend(r.Context(), userID, "Password Restore", emailContent)
 
 	log.Println(errEmailSent)
 

--- a/api_password_restore_test.go
+++ b/api_password_restore_test.go
@@ -1,6 +1,7 @@
 package auth
 
 import (
+	"context"
 	"errors"
 	"net/url"
 	"testing"
@@ -47,7 +48,7 @@ func TestPasswordRestoreEndpointUserNotFound(t *testing.T) {
 	NotNil(t, authInstance)
 
 	// Mock user not found
-	authInstance.funcUserFindByUsername = func(username string, firstName string, lastName string, options UserAuthOptions) (userID string, err error) {
+	authInstance.funcUserFindByUsername = func(ctx context.Context, username string, firstName string, lastName string, options UserAuthOptions) (userID string, err error) {
 		return "", nil
 	}
 
@@ -65,7 +66,7 @@ func TestPasswordRestoreEndpointInternalError(t *testing.T) {
 	NotNil(t, authInstance)
 
 	// Mock internal error
-	authInstance.funcUserFindByUsername = func(username string, firstName string, lastName string, options UserAuthOptions) (userID string, err error) {
+	authInstance.funcUserFindByUsername = func(ctx context.Context, username string, firstName string, lastName string, options UserAuthOptions) (userID string, err error) {
 		return "", errors.New("db error")
 	}
 
@@ -83,13 +84,13 @@ func TestPasswordRestoreEndpointSuccess(t *testing.T) {
 	NotNil(t, authInstance)
 
 	// Mock success
-	authInstance.funcUserFindByUsername = func(username string, firstName string, lastName string, options UserAuthOptions) (userID string, err error) {
+	authInstance.funcUserFindByUsername = func(ctx context.Context, username string, firstName string, lastName string, options UserAuthOptions) (userID string, err error) {
 		return "user123", nil
 	}
 	authInstance.funcTemporaryKeySet = func(key string, value string, expiresSeconds int) (err error) {
 		return nil
 	}
-	authInstance.funcEmailSend = func(userID string, emailSubject string, emailBody string) (err error) {
+	authInstance.funcEmailSend = func(ctx context.Context, userID string, emailSubject string, emailBody string) (err error) {
 		return nil
 	}
 

--- a/api_register.go
+++ b/api_register.go
@@ -78,12 +78,12 @@ func (a Auth) apiRegisterPasswordless(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	emailContent := a.passwordlessFuncEmailTemplateRegisterCode(email, verificationCode, UserAuthOptions{
+	emailContent := a.passwordlessFuncEmailTemplateRegisterCode(r.Context(), email, verificationCode, UserAuthOptions{
 		UserIp:    req.GetIP(r),
 		UserAgent: r.UserAgent(),
 	})
 
-	errEmailSent := a.passwordlessFuncEmailSend(email, "Registration Code", emailContent)
+	errEmailSent := a.passwordlessFuncEmailSend(r.Context(), email, "Registration Code", emailContent)
 
 	if errEmailSent != nil {
 		log.Println(errEmailSent)
@@ -105,7 +105,7 @@ func (a Auth) apiRegisterUsernameAndPassword(w http.ResponseWriter, r *http.Requ
 	first_name := req.GetStringTrimmed(r, "first_name")
 	last_name := req.GetStringTrimmed(r, "last_name")
 
-	response := a.RegisterWithUsernameAndPassword(email, password, first_name, last_name, UserAuthOptions{
+	response := a.RegisterWithUsernameAndPassword(r.Context(), email, password, first_name, last_name, UserAuthOptions{
 		UserIp:    req.GetIP(r),
 		UserAgent: r.UserAgent(),
 	})

--- a/api_register_code_verify.go
+++ b/api_register_code_verify.go
@@ -72,12 +72,12 @@ func (a Auth) apiRegisterCodeVerify(w http.ResponseWriter, r *http.Request) {
 	var errRegister error = nil
 
 	if a.passwordless {
-		errRegister = a.passwordlessFuncUserRegister(email, firstName, lastName, UserAuthOptions{
+		errRegister = a.passwordlessFuncUserRegister(r.Context(), email, firstName, lastName, UserAuthOptions{
 			UserIp:    req.GetIP(r),
 			UserAgent: r.UserAgent(),
 		})
 	} else {
-		errRegister = a.funcUserRegister(email, password, firstName, lastName, UserAuthOptions{
+		errRegister = a.funcUserRegister(r.Context(), email, password, firstName, lastName, UserAuthOptions{
 			UserIp:    req.GetIP(r),
 			UserAgent: r.UserAgent(),
 		})

--- a/api_register_code_verify_test.go
+++ b/api_register_code_verify_test.go
@@ -1,6 +1,7 @@
 package auth
 
 import (
+	"context"
 	"errors"
 	"net/url"
 	"testing"
@@ -89,7 +90,7 @@ func TestApiRegisterCodeVerifyRegistrationFailed(t *testing.T) {
 		return jsonPayload, nil
 	}
 
-	authInstance.passwordlessFuncUserRegister = func(email string, firstName string, lastName string, options UserAuthOptions) (err error) {
+	authInstance.passwordlessFuncUserRegister = func(ctx context.Context, email string, firstName string, lastName string, options UserAuthOptions) (err error) {
 		return errors.New("db error")
 	}
 
@@ -111,11 +112,11 @@ func TestApiRegisterCodeVerifyAuthenticationError(t *testing.T) {
 		return jsonPayload, nil
 	}
 
-	authInstance.passwordlessFuncUserRegister = func(email string, firstName string, lastName string, options UserAuthOptions) (err error) {
+	authInstance.passwordlessFuncUserRegister = func(ctx context.Context, email string, firstName string, lastName string, options UserAuthOptions) (err error) {
 		return nil
 	}
 
-	authInstance.passwordlessFuncUserFindByEmail = func(email string, options UserAuthOptions) (userID string, err error) {
+	authInstance.passwordlessFuncUserFindByEmail = func(ctx context.Context, email string, options UserAuthOptions) (userID string, err error) {
 		return "", errors.New("db error")
 	}
 
@@ -137,11 +138,11 @@ func TestApiRegisterCodeVerifyUserNotFound(t *testing.T) {
 		return jsonPayload, nil
 	}
 
-	authInstance.passwordlessFuncUserRegister = func(email string, firstName string, lastName string, options UserAuthOptions) (err error) {
+	authInstance.passwordlessFuncUserRegister = func(ctx context.Context, email string, firstName string, lastName string, options UserAuthOptions) (err error) {
 		return nil
 	}
 
-	authInstance.passwordlessFuncUserFindByEmail = func(email string, options UserAuthOptions) (userID string, err error) {
+	authInstance.passwordlessFuncUserFindByEmail = func(ctx context.Context, email string, options UserAuthOptions) (userID string, err error) {
 		return "", nil
 	}
 
@@ -163,15 +164,15 @@ func TestApiRegisterCodeVerifyTokenStoreError(t *testing.T) {
 		return jsonPayload, nil
 	}
 
-	authInstance.passwordlessFuncUserRegister = func(email string, firstName string, lastName string, options UserAuthOptions) (err error) {
+	authInstance.passwordlessFuncUserRegister = func(ctx context.Context, email string, firstName string, lastName string, options UserAuthOptions) (err error) {
 		return nil
 	}
 
-	authInstance.passwordlessFuncUserFindByEmail = func(email string, options UserAuthOptions) (userID string, err error) {
+	authInstance.passwordlessFuncUserFindByEmail = func(ctx context.Context, email string, options UserAuthOptions) (userID string, err error) {
 		return "user123", nil
 	}
 
-	authInstance.funcUserStoreAuthToken = func(sessionID string, userID string, options UserAuthOptions) (err error) {
+	authInstance.funcUserStoreAuthToken = func(ctx context.Context, token string, userID string, options UserAuthOptions) error {
 		return errors.New("db error")
 	}
 
@@ -193,15 +194,15 @@ func TestApiRegisterCodeVerifySuccess(t *testing.T) {
 		return jsonPayload, nil
 	}
 
-	authInstance.passwordlessFuncUserRegister = func(email string, firstName string, lastName string, options UserAuthOptions) (err error) {
+	authInstance.passwordlessFuncUserRegister = func(ctx context.Context, email string, firstName string, lastName string, options UserAuthOptions) (err error) {
 		return nil
 	}
 
-	authInstance.passwordlessFuncUserFindByEmail = func(email string, options UserAuthOptions) (userID string, err error) {
+	authInstance.passwordlessFuncUserFindByEmail = func(ctx context.Context, email string, options UserAuthOptions) (userID string, err error) {
 		return "user123", nil
 	}
 
-	authInstance.funcUserStoreAuthToken = func(sessionID string, userID string, options UserAuthOptions) (err error) {
+	authInstance.funcUserStoreAuthToken = func(ctx context.Context, token string, userID string, options UserAuthOptions) error {
 		return nil
 	}
 

--- a/api_register_test.go
+++ b/api_register_test.go
@@ -1,6 +1,7 @@
 package auth
 
 import (
+	"context"
 	"errors"
 	"net/http"
 	"net/url"
@@ -101,7 +102,7 @@ func TestApiRegisterUsernameAndPasswordRegistrationFailed(t *testing.T) {
 	Nil(t, err)
 	NotNil(t, authInstance)
 
-	authInstance.funcUserRegister = func(username string, password string, firstName string, lastName string, options UserAuthOptions) (err error) {
+	authInstance.funcUserRegister = func(ctx context.Context, username string, password string, firstName string, lastName string, options UserAuthOptions) (err error) {
 		return errors.New("db error")
 	}
 
@@ -121,7 +122,7 @@ func TestApiRegisterUsernameAndPasswordSuccess(t *testing.T) {
 	Nil(t, err)
 	NotNil(t, authInstance)
 
-	authInstance.funcUserRegister = func(username string, password string, firstName string, lastName string, options UserAuthOptions) (err error) {
+	authInstance.funcUserRegister = func(ctx context.Context, username string, password string, firstName string, lastName string, options UserAuthOptions) (err error) {
 		return nil
 	}
 
@@ -225,7 +226,7 @@ func TestApiRegisterPasswordlessEmailSendError(t *testing.T) {
 	Nil(t, err)
 	NotNil(t, authInstance)
 
-	authInstance.passwordlessFuncEmailSend = func(email string, emailSubject string, emailBody string) (err error) {
+	authInstance.passwordlessFuncEmailSend = func(ctx context.Context, email string, emailSubject string, emailBody string) (err error) {
 		return errors.New("smtp error")
 	}
 

--- a/auth.go
+++ b/auth.go
@@ -1,6 +1,7 @@
 package auth
 
 import (
+	"context"
 	"net/http"
 	"strings"
 	"time"
@@ -25,29 +26,29 @@ type Auth struct {
 	funcLayout              func(content string) string
 	funcTemporaryKeyGet     func(key string) (value string, err error)
 	funcTemporaryKeySet     func(key string, value string, expiresSeconds int) (err error)
-	funcUserFindByAuthToken func(token string, options UserAuthOptions) (userID string, err error)
-	funcUserLogout          func(userID string, options UserAuthOptions) (err error)
-	funcUserStoreAuthToken  func(token string, userID string, options UserAuthOptions) error
+	funcUserFindByAuthToken func(ctx context.Context, token string, options UserAuthOptions) (userID string, err error)
+	funcUserLogout          func(ctx context.Context, userID string, options UserAuthOptions) (err error)
+	funcUserStoreAuthToken  func(ctx context.Context, token string, userID string, options UserAuthOptions) error
 	// ===== END: shared by all implementations
 
 	// ===== START: username(email) and password options
 	enableVerification               bool
-	funcEmailTemplatePasswordRestore func(userID string, passwordRestoreLink string, options UserAuthOptions) string // optional
-	funcEmailTemplateRegisterCode    func(email string, passwordRestoreLink string, options UserAuthOptions) string  // optional
-	funcEmailSend                    func(userID string, emailSubject string, emailBody string) (err error)
-	funcUserLogin                    func(username string, password string, options UserAuthOptions) (userID string, err error)
-	funcUserPasswordChange           func(username string, newPassword string, options UserAuthOptions) (err error)
-	funcUserRegister                 func(username string, password string, first_name string, last_name string, options UserAuthOptions) (err error)
-	funcUserFindByUsername           func(username string, first_name string, last_name string, options UserAuthOptions) (userID string, err error)
+	funcEmailTemplatePasswordRestore func(ctx context.Context, userID string, passwordRestoreLink string, options UserAuthOptions) string // optional
+	funcEmailTemplateRegisterCode    func(ctx context.Context, email string, passwordRestoreLink string, options UserAuthOptions) string  // optional
+	funcEmailSend                    func(ctx context.Context, userID string, emailSubject string, emailBody string) (err error)
+	funcUserLogin                    func(ctx context.Context, username string, password string, options UserAuthOptions) (userID string, err error)
+	funcUserPasswordChange           func(ctx context.Context, username string, newPassword string, options UserAuthOptions) (err error)
+	funcUserRegister                 func(ctx context.Context, username string, password string, first_name string, last_name string, options UserAuthOptions) (err error)
+	funcUserFindByUsername           func(ctx context.Context, username string, first_name string, last_name string, options UserAuthOptions) (userID string, err error)
 	// ===== END: username(email) and password options
 
 	// ===== START: passwordless options
 	passwordless                              bool
-	passwordlessFuncUserFindByEmail           func(email string, options UserAuthOptions) (userID string, err error)
-	passwordlessFuncEmailTemplateLoginCode    func(email string, passwordRestoreLink string, options UserAuthOptions) string // optional
-	passwordlessFuncEmailTemplateRegisterCode func(email string, passwordRestoreLink string, options UserAuthOptions) string // optional
-	passwordlessFuncEmailSend                 func(email string, emailSubject string, emailBody string) (err error)
-	passwordlessFuncUserRegister              func(email string, firstName string, lastName string, options UserAuthOptions) (err error)
+	passwordlessFuncUserFindByEmail           func(ctx context.Context, email string, options UserAuthOptions) (userID string, err error)
+	passwordlessFuncEmailTemplateLoginCode    func(ctx context.Context, email string, passwordRestoreLink string, options UserAuthOptions) string // optional
+	passwordlessFuncEmailTemplateRegisterCode func(ctx context.Context, email string, passwordRestoreLink string, options UserAuthOptions) string // optional
+	passwordlessFuncEmailSend                 func(ctx context.Context, email string, emailSubject string, emailBody string) (err error)
+	passwordlessFuncUserRegister              func(ctx context.Context, email string, firstName string, lastName string, options UserAuthOptions) (err error)
 	// ===== END: passwordless options
 
 	// ===== START: rate limiting

--- a/auth_middleware_test.go
+++ b/auth_middleware_test.go
@@ -1,21 +1,33 @@
 package auth
 
+import (
+	"context"
+)
+
 func newPasswordlessAuthForMiddlewareTests(useCookies bool) (*Auth, error) {
 	return NewPasswordlessAuth(ConfigPasswordless{
 		Endpoint:             "/auth",
 		UrlRedirectOnSuccess: "/user",
 		FuncTemporaryKeyGet:  func(key string) (value string, err error) { return "", nil },
 		FuncTemporaryKeySet:  func(key, value string, expiresSeconds int) (err error) { return nil },
-		FuncUserFindByAuthToken: func(sessionID string, options UserAuthOptions) (userID string, err error) {
+		FuncUserFindByAuthToken: func(ctx context.Context, sessionID string, options UserAuthOptions) (userID string, err error) {
 			// Default: no user found
 			return "", nil
 		},
-		FuncUserFindByEmail:    func(email string, options UserAuthOptions) (userID string, err error) { return "", nil },
-		FuncUserLogout:         func(userID string, options UserAuthOptions) (err error) { return nil },
-		FuncUserStoreAuthToken: func(sessionID, userID string, options UserAuthOptions) error { return nil },
-		FuncEmailSend:          func(email, emailSubject, emailBody string) (err error) { return nil },
-		UseCookies:             useCookies,
-		UseLocalStorage:        !useCookies,
+		FuncUserFindByEmail: func(ctx context.Context, email string, options UserAuthOptions) (userID string, err error) {
+			return "", nil
+		},
+		FuncUserLogout: func(ctx context.Context, userID string, options UserAuthOptions) (err error) {
+			return nil
+		},
+		FuncUserStoreAuthToken: func(ctx context.Context, sessionID, userID string, options UserAuthOptions) error {
+			return nil
+		},
+		FuncEmailSend: func(ctx context.Context, email, emailSubject, emailBody string) (err error) {
+			return nil
+		},
+		UseCookies:      useCookies,
+		UseLocalStorage: !useCookies,
 	})
 }
 

--- a/config_passwordless.go
+++ b/config_passwordless.go
@@ -1,6 +1,9 @@
 package auth
 
-import "time"
+import (
+	"context"
+	"time"
+)
 
 type ConfigPasswordless struct {
 
@@ -10,9 +13,9 @@ type ConfigPasswordless struct {
 	FuncLayout              func(content string) string
 	FuncTemporaryKeyGet     func(key string) (value string, err error)
 	FuncTemporaryKeySet     func(key string, value string, expiresSeconds int) (err error)
-	FuncUserFindByAuthToken func(sessionID string, options UserAuthOptions) (userID string, err error)
-	FuncUserLogout          func(userID string, options UserAuthOptions) (err error)
-	FuncUserStoreAuthToken  func(sessionID string, userID string, options UserAuthOptions) error
+	FuncUserFindByAuthToken func(ctx context.Context, sessionID string, options UserAuthOptions) (userID string, err error)
+	FuncUserLogout          func(ctx context.Context, userID string, options UserAuthOptions) (err error)
+	FuncUserStoreAuthToken  func(ctx context.Context, sessionID string, userID string, options UserAuthOptions) error
 	UrlRedirectOnSuccess    string
 	UseCookies              bool
 	UseLocalStorage         bool
@@ -28,10 +31,10 @@ type ConfigPasswordless struct {
 	// ===== END: shared by all implementations
 
 	// ===== START: passwordless options
-	FuncUserFindByEmail           func(email string, options UserAuthOptions) (userID string, err error)
-	FuncEmailTemplateLoginCode    func(email string, logingLink string, options UserAuthOptions) string   // optional
-	FuncEmailTemplateRegisterCode func(email string, registerLink string, options UserAuthOptions) string // optional
-	FuncEmailSend                 func(email string, emailSubject string, emailBody string) (err error)
-	FuncUserRegister              func(email string, firstName string, lastName string, options UserAuthOptions) (err error)
+	FuncUserFindByEmail           func(ctx context.Context, email string, options UserAuthOptions) (userID string, err error)
+	FuncEmailTemplateLoginCode    func(ctx context.Context, email string, logingLink string, options UserAuthOptions) string   // optional
+	FuncEmailTemplateRegisterCode func(ctx context.Context, email string, registerLink string, options UserAuthOptions) string // optional
+	FuncEmailSend                 func(ctx context.Context, email string, emailSubject string, emailBody string) (err error)
+	FuncUserRegister              func(ctx context.Context, email string, firstName string, lastName string, options UserAuthOptions) (err error)
 	// ===== END: passwordless options
 }

--- a/config_username_and_password.go
+++ b/config_username_and_password.go
@@ -1,6 +1,7 @@
 package auth
 
 import (
+	"context"
 	"time"
 )
 
@@ -12,8 +13,8 @@ type ConfigUsernameAndPassword struct {
 	FuncLayout              func(content string) string
 	FuncTemporaryKeyGet     func(key string) (value string, err error)
 	FuncTemporaryKeySet     func(key string, value string, expiresSeconds int) (err error)
-	FuncUserStoreAuthToken  func(sessionID string, userID string, options UserAuthOptions) error
-	FuncUserFindByAuthToken func(sessionID string, options UserAuthOptions) (userID string, err error)
+	FuncUserStoreAuthToken  func(ctx context.Context, sessionID string, userID string, options UserAuthOptions) error
+	FuncUserFindByAuthToken func(ctx context.Context, sessionID string, options UserAuthOptions) (userID string, err error)
 	UrlRedirectOnSuccess    string
 	UseCookies              bool
 	UseLocalStorage         bool
@@ -30,14 +31,14 @@ type ConfigUsernameAndPassword struct {
 
 	// ===== START: username(email) and password options
 	EnableVerification               bool
-	FuncEmailTemplatePasswordRestore func(userID string, passwordRestoreLink string, options UserAuthOptions) string // optional
-	FuncEmailTemplateRegisterCode    func(userID string, passwordRestoreLink string, options UserAuthOptions) string // optional
-	FuncEmailSend                    func(userID string, emailSubject string, emailBody string) (err error)
-	FuncUserFindByUsername           func(username string, firstName string, lastName string, options UserAuthOptions) (userID string, err error)
-	FuncUserLogin                    func(username string, password string, options UserAuthOptions) (userID string, err error)
-	FuncUserLogout                   func(userID string, options UserAuthOptions) (err error)
-	FuncUserPasswordChange           func(username string, newPassword string, options UserAuthOptions) (err error)
-	FuncUserRegister                 func(username string, password string, first_name string, last_name string, options UserAuthOptions) (err error)
+	FuncEmailTemplatePasswordRestore func(ctx context.Context, userID string, passwordRestoreLink string, options UserAuthOptions) string // optional
+	FuncEmailTemplateRegisterCode    func(ctx context.Context, userID string, passwordRestoreLink string, options UserAuthOptions) string // optional
+	FuncEmailSend                    func(ctx context.Context, userID string, emailSubject string, emailBody string) (err error)
+	FuncUserFindByUsername           func(ctx context.Context, username string, firstName string, lastName string, options UserAuthOptions) (userID string, err error)
+	FuncUserLogin                    func(ctx context.Context, username string, password string, options UserAuthOptions) (userID string, err error)
+	FuncUserLogout                   func(ctx context.Context, userID string, options UserAuthOptions) (err error)
+	FuncUserPasswordChange           func(ctx context.Context, username string, newPassword string, options UserAuthOptions) (err error)
+	FuncUserRegister                 func(ctx context.Context, username string, password string, first_name string, last_name string, options UserAuthOptions) (err error)
 	LabelUsername                    string
 	// ===== END: username(email) and password options
 }

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -102,20 +102,20 @@ type ConfigPasswordless struct {
     // Required
     Endpoint                string
     UrlRedirectOnSuccess    string
-    FuncUserFindByAuthToken func(sessionID string, options UserAuthOptions) (userID string, err error)
-    FuncUserFindByEmail     func(email string, options UserAuthOptions) (userID string, err error)
-    FuncUserLogout          func(userID string, options UserAuthOptions) error
-    FuncUserStoreAuthToken  func(sessionID string, userID string, options UserAuthOptions) error
-    FuncEmailSend           func(email string, subject string, body string) error
+    FuncUserFindByAuthToken func(ctx context.Context, sessionID string, options UserAuthOptions) (userID string, err error)
+    FuncUserFindByEmail     func(ctx context.Context, email string, options UserAuthOptions) (userID string, err error)
+    FuncUserLogout          func(ctx context.Context, userID string, options UserAuthOptions) error
+    FuncUserStoreAuthToken  func(ctx context.Context, sessionID string, userID string, options UserAuthOptions) error
+    FuncEmailSend           func(ctx context.Context, email string, subject string, body string) error
     FuncTemporaryKeyGet     func(key string) (value string, err error)
     FuncTemporaryKeySet     func(key string, value string, expiresSeconds int) error
     UseCookies              bool // OR UseLocalStorage (one must be true)
     
     // Optional
     EnableRegistration           bool
-    FuncUserRegister             func(email, firstName, lastName string, options UserAuthOptions) error
-    FuncEmailTemplateLoginCode   func(email, loginLink string, options UserAuthOptions) string
-    FuncEmailTemplateRegisterCode func(email, registerLink string, options UserAuthOptions) string
+    FuncUserRegister             func(ctx context.Context, email, firstName, lastName string, options UserAuthOptions) error
+    FuncEmailTemplateLoginCode   func(ctx context.Context, email, loginLink string, options UserAuthOptions) string
+    FuncEmailTemplateRegisterCode func(ctx context.Context, email, registerLink string, options UserAuthOptions) string
     FuncLayout                   func(content string) string
 }
 ```
@@ -124,10 +124,10 @@ type ConfigPasswordless struct {
 ```go
 type ConfigUsernameAndPassword struct {
     // Similar to passwordless, plus:
-    FuncUserLogin          func(username, password string, options UserAuthOptions) (userID string, err error)
-    FuncUserPasswordChange func(username, newPassword string, options UserAuthOptions) error
-    FuncUserRegister       func(username, password, firstName, lastName string, options UserAuthOptions) error
-    FuncUserFindByUsername func(username, firstName, lastName string, options UserAuthOptions) (userID string, err error)
+    FuncUserLogin          func(ctx context.Context, username, password string, options UserAuthOptions) (userID string, err error)
+    FuncUserPasswordChange func(ctx context.Context, username, newPassword string, options UserAuthOptions) error
+    FuncUserRegister       func(ctx context.Context, username, password, firstName, lastName string, options UserAuthOptions) error
+    FuncUserFindByUsername func(ctx context.Context, username, firstName, lastName string, options UserAuthOptions) (userID string, err error)
     EnableVerification     bool // Email verification for registration
 }
 ```
@@ -344,7 +344,7 @@ func dashboardHandler(w http.ResponseWriter, r *http.Request) {
 3. **Complete UI Included** - HTML pages with Bootstrap styling
 4. **Token Storage Options** - Cookies OR localStorage (configurable)
 5. **Verification Codes** - 8-character codes from limited alphabet (BCDFGHJKLMNPQRSTVXYZ) to avoid confusion
-6. **UserAuthOptions** - Passes IP and UserAgent to all callbacks for audit trails
+6. **UserAuthOptions + Context** - Callbacks receive `ctx context.Context` plus IP and UserAgent metadata for audit trails and cancellation
 
 ---
 

--- a/login_with_username_and_password.go
+++ b/login_with_username_and_password.go
@@ -1,6 +1,7 @@
 package auth
 
 import (
+	"context"
 	"net/mail"
 
 	"github.com/dracory/str"
@@ -12,7 +13,7 @@ type LoginUsernameAndPasswordResponse struct {
 	Token          string
 }
 
-func (a Auth) LoginWithUsernameAndPassword(email string, password string, options UserAuthOptions) (response LoginUsernameAndPasswordResponse) {
+func (a Auth) LoginWithUsernameAndPassword(ctx context.Context, email string, password string, options UserAuthOptions) (response LoginUsernameAndPasswordResponse) {
 	if email == "" {
 		response.ErrorMessage = "Email is required field"
 		return response
@@ -28,7 +29,7 @@ func (a Auth) LoginWithUsernameAndPassword(email string, password string, option
 		return response
 	}
 
-	userID, err := a.funcUserLogin(email, password, options)
+	userID, err := a.funcUserLogin(ctx, email, password, options)
 
 	if err != nil {
 		response.ErrorMessage = "authentication failed. " + err.Error()
@@ -46,7 +47,7 @@ func (a Auth) LoginWithUsernameAndPassword(email string, password string, option
 		return response
 	}
 
-	errSession := a.funcUserStoreAuthToken(token, userID, options)
+	errSession := a.funcUserStoreAuthToken(ctx, token, userID, options)
 
 	if errSession != nil {
 		response.ErrorMessage = "token store failed. " + errSession.Error()

--- a/new_passwordless_auth.go
+++ b/new_passwordless_auth.go
@@ -1,6 +1,7 @@
 package auth
 
 import (
+	"context"
 	"errors"
 	"time"
 )
@@ -80,12 +81,16 @@ func NewPasswordlessAuth(config ConfigPasswordless) (*Auth, error) {
 
 	// If no user defined email template is set, use default
 	if auth.passwordlessFuncEmailTemplateLoginCode == nil {
-		auth.passwordlessFuncEmailTemplateLoginCode = emailLoginCodeTemplate
+		auth.passwordlessFuncEmailTemplateLoginCode = func(ctx context.Context, email string, code string, options UserAuthOptions) string {
+			return emailLoginCodeTemplate(email, code, options)
+		}
 	}
 
 	// If no user defined email template is set, use default
 	if auth.passwordlessFuncEmailTemplateRegisterCode == nil {
-		auth.passwordlessFuncEmailTemplateRegisterCode = emailRegisterCodeTemplate
+		auth.passwordlessFuncEmailTemplateRegisterCode = func(ctx context.Context, email string, code string, options UserAuthOptions) string {
+			return emailRegisterCodeTemplate(email, code, options)
+		}
 	}
 
 	// Initialize rate limiting

--- a/new_passwordless_auth_test.go
+++ b/new_passwordless_auth_test.go
@@ -1,6 +1,7 @@
 package auth
 
 import (
+	"context"
 	"testing"
 )
 
@@ -70,11 +71,13 @@ func TestNewPasswordlessAuth_FuncUserFindByAuthTokenIsRequired(t *testing.T) {
 
 func TestNewPasswordlessAuth_FuncUserFindByEmailIsRequired(t *testing.T) {
 	_, err := NewPasswordlessAuth(ConfigPasswordless{
-		Endpoint:                "/auth",
-		UrlRedirectOnSuccess:    "/user",
-		FuncTemporaryKeyGet:     func(key string) (value string, err error) { return "", nil },
-		FuncTemporaryKeySet:     func(key, value string, expiresSeconds int) (err error) { return nil },
-		FuncUserFindByAuthToken: func(sessionID string, options UserAuthOptions) (userID string, err error) { return "", nil },
+		Endpoint:             "/auth",
+		UrlRedirectOnSuccess: "/user",
+		FuncTemporaryKeyGet:  func(key string) (value string, err error) { return "", nil },
+		FuncTemporaryKeySet:  func(key, value string, expiresSeconds int) (err error) { return nil },
+		FuncUserFindByAuthToken: func(ctx context.Context, sessionID string, options UserAuthOptions) (userID string, err error) {
+			return "", nil
+		},
 	})
 	if err == nil {
 		t.Fatal("Error SHOULD NOT BE NULL")
@@ -86,12 +89,16 @@ func TestNewPasswordlessAuth_FuncUserFindByEmailIsRequired(t *testing.T) {
 
 func TestNewPasswordlessAuth_FuncUserLogoutIsRequired(t *testing.T) {
 	_, err := NewPasswordlessAuth(ConfigPasswordless{
-		Endpoint:                "/auth",
-		UrlRedirectOnSuccess:    "/user",
-		FuncTemporaryKeyGet:     func(key string) (value string, err error) { return "", nil },
-		FuncTemporaryKeySet:     func(key, value string, expiresSeconds int) (err error) { return nil },
-		FuncUserFindByAuthToken: func(sessionID string, options UserAuthOptions) (userID string, err error) { return "", nil },
-		FuncUserFindByEmail:     func(email string, options UserAuthOptions) (userID string, err error) { return "", nil },
+		Endpoint:             "/auth",
+		UrlRedirectOnSuccess: "/user",
+		FuncTemporaryKeyGet:  func(key string) (value string, err error) { return "", nil },
+		FuncTemporaryKeySet:  func(key, value string, expiresSeconds int) (err error) { return nil },
+		FuncUserFindByAuthToken: func(ctx context.Context, sessionID string, options UserAuthOptions) (userID string, err error) {
+			return "", nil
+		},
+		FuncUserFindByEmail: func(ctx context.Context, email string, options UserAuthOptions) (userID string, err error) {
+			return "", nil
+		},
 	})
 	if err == nil {
 		t.Fatal("Error SHOULD NOT BE NULL")
@@ -103,13 +110,17 @@ func TestNewPasswordlessAuth_FuncUserLogoutIsRequired(t *testing.T) {
 
 func TestNewPasswordlessAuth_FuncUserStoreTokenFuncUserStoreTokenIsRequired(t *testing.T) {
 	_, err := NewPasswordlessAuth(ConfigPasswordless{
-		Endpoint:                "/auth",
-		UrlRedirectOnSuccess:    "/user",
-		FuncTemporaryKeyGet:     func(key string) (value string, err error) { return "", nil },
-		FuncTemporaryKeySet:     func(key, value string, expiresSeconds int) (err error) { return nil },
-		FuncUserFindByAuthToken: func(sessionID string, options UserAuthOptions) (userID string, err error) { return "", nil },
-		FuncUserFindByEmail:     func(email string, options UserAuthOptions) (userID string, err error) { return "", nil },
-		FuncUserLogout:          func(userID string, options UserAuthOptions) (err error) { return nil },
+		Endpoint:             "/auth",
+		UrlRedirectOnSuccess: "/user",
+		FuncTemporaryKeyGet:  func(key string) (value string, err error) { return "", nil },
+		FuncTemporaryKeySet:  func(key, value string, expiresSeconds int) (err error) { return nil },
+		FuncUserFindByAuthToken: func(ctx context.Context, sessionID string, options UserAuthOptions) (userID string, err error) {
+			return "", nil
+		},
+		FuncUserFindByEmail: func(ctx context.Context, email string, options UserAuthOptions) (userID string, err error) {
+			return "", nil
+		},
+		FuncUserLogout: func(ctx context.Context, userID string, options UserAuthOptions) (err error) { return nil },
 	})
 	if err == nil {
 		t.Fatal("Error SHOULD NOT BE NULL")
@@ -121,14 +132,18 @@ func TestNewPasswordlessAuth_FuncUserStoreTokenFuncUserStoreTokenIsRequired(t *t
 
 func TestNewPasswordlessAuth_FuncEmailSendIsRequired(t *testing.T) {
 	_, err := NewPasswordlessAuth(ConfigPasswordless{
-		Endpoint:                "/auth",
-		UrlRedirectOnSuccess:    "/user",
-		FuncTemporaryKeyGet:     func(key string) (value string, err error) { return "", nil },
-		FuncTemporaryKeySet:     func(key, value string, expiresSeconds int) (err error) { return nil },
-		FuncUserFindByAuthToken: func(sessionID string, options UserAuthOptions) (userID string, err error) { return "", nil },
-		FuncUserFindByEmail:     func(email string, options UserAuthOptions) (userID string, err error) { return "", nil },
-		FuncUserLogout:          func(userID string, options UserAuthOptions) (err error) { return nil },
-		FuncUserStoreAuthToken:  func(sessionID, userID string, options UserAuthOptions) error { return nil },
+		Endpoint:             "/auth",
+		UrlRedirectOnSuccess: "/user",
+		FuncTemporaryKeyGet:  func(key string) (value string, err error) { return "", nil },
+		FuncTemporaryKeySet:  func(key, value string, expiresSeconds int) (err error) { return nil },
+		FuncUserFindByAuthToken: func(ctx context.Context, sessionID string, options UserAuthOptions) (userID string, err error) {
+			return "", nil
+		},
+		FuncUserFindByEmail: func(ctx context.Context, email string, options UserAuthOptions) (userID string, err error) {
+			return "", nil
+		},
+		FuncUserLogout:         func(ctx context.Context, userID string, options UserAuthOptions) (err error) { return nil },
+		FuncUserStoreAuthToken: func(ctx context.Context, sessionID, userID string, options UserAuthOptions) error { return nil },
 	})
 	if err == nil {
 		t.Fatal("Error SHOULD NOT BE NULL")
@@ -140,15 +155,19 @@ func TestNewPasswordlessAuth_FuncEmailSendIsRequired(t *testing.T) {
 
 func TestNewPasswordlessAuth_UseCookiesAndLocalStorageCannotBeBothFalse(t *testing.T) {
 	_, err := NewPasswordlessAuth(ConfigPasswordless{
-		Endpoint:                "/auth",
-		UrlRedirectOnSuccess:    "/user",
-		FuncTemporaryKeyGet:     func(key string) (value string, err error) { return "", nil },
-		FuncTemporaryKeySet:     func(key, value string, expiresSeconds int) (err error) { return nil },
-		FuncUserFindByAuthToken: func(sessionID string, options UserAuthOptions) (userID string, err error) { return "", nil },
-		FuncUserFindByEmail:     func(email string, options UserAuthOptions) (userID string, err error) { return "", nil },
-		FuncUserLogout:          func(userID string, options UserAuthOptions) (err error) { return nil },
-		FuncUserStoreAuthToken:  func(sessionID, userID string, options UserAuthOptions) error { return nil },
-		FuncEmailSend:           func(email, emailSubject, emailBody string) (err error) { return nil },
+		Endpoint:             "/auth",
+		UrlRedirectOnSuccess: "/user",
+		FuncTemporaryKeyGet:  func(key string) (value string, err error) { return "", nil },
+		FuncTemporaryKeySet:  func(key, value string, expiresSeconds int) (err error) { return nil },
+		FuncUserFindByAuthToken: func(ctx context.Context, sessionID string, options UserAuthOptions) (userID string, err error) {
+			return "", nil
+		},
+		FuncUserFindByEmail: func(ctx context.Context, email string, options UserAuthOptions) (userID string, err error) {
+			return "", nil
+		},
+		FuncUserLogout:         func(ctx context.Context, userID string, options UserAuthOptions) (err error) { return nil },
+		FuncUserStoreAuthToken: func(ctx context.Context, sessionID, userID string, options UserAuthOptions) error { return nil },
+		FuncEmailSend:          func(ctx context.Context, email, emailSubject, emailBody string) (err error) { return nil },
 	})
 	if err == nil {
 		t.Fatal("Error SHOULD NOT BE NULL")
@@ -160,17 +179,21 @@ func TestNewPasswordlessAuth_UseCookiesAndLocalStorageCannotBeBothFalse(t *testi
 
 func TestNewPasswordlessAuth_UseCookiesAndLocalStorageCannotBeBothTrue(t *testing.T) {
 	_, err := NewPasswordlessAuth(ConfigPasswordless{
-		Endpoint:                "/auth",
-		UrlRedirectOnSuccess:    "/user",
-		FuncTemporaryKeyGet:     func(key string) (value string, err error) { return "", nil },
-		FuncTemporaryKeySet:     func(key, value string, expiresSeconds int) (err error) { return nil },
-		FuncUserFindByAuthToken: func(sessionID string, options UserAuthOptions) (userID string, err error) { return "", nil },
-		FuncUserFindByEmail:     func(email string, options UserAuthOptions) (userID string, err error) { return "", nil },
-		FuncUserLogout:          func(userID string, options UserAuthOptions) (err error) { return nil },
-		FuncUserStoreAuthToken:  func(sessionID, userID string, options UserAuthOptions) error { return nil },
-		FuncEmailSend:           func(email, emailSubject, emailBody string) (err error) { return nil },
-		UseCookies:              true,
-		UseLocalStorage:         true,
+		Endpoint:             "/auth",
+		UrlRedirectOnSuccess: "/user",
+		FuncTemporaryKeyGet:  func(key string) (value string, err error) { return "", nil },
+		FuncTemporaryKeySet:  func(key, value string, expiresSeconds int) (err error) { return nil },
+		FuncUserFindByAuthToken: func(ctx context.Context, sessionID string, options UserAuthOptions) (userID string, err error) {
+			return "", nil
+		},
+		FuncUserFindByEmail: func(ctx context.Context, email string, options UserAuthOptions) (userID string, err error) {
+			return "", nil
+		},
+		FuncUserLogout:         func(ctx context.Context, userID string, options UserAuthOptions) (err error) { return nil },
+		FuncUserStoreAuthToken: func(ctx context.Context, sessionID, userID string, options UserAuthOptions) error { return nil },
+		FuncEmailSend:          func(ctx context.Context, email, emailSubject, emailBody string) (err error) { return nil },
+		UseCookies:             true,
+		UseLocalStorage:        true,
 	})
 	if err == nil {
 		t.Fatal("Error SHOULD NOT BE NULL")
@@ -182,17 +205,21 @@ func TestNewPasswordlessAuth_UseCookiesAndLocalStorageCannotBeBothTrue(t *testin
 
 func TestNewPasswordlessAuth_UseCookiesAndLocalStorageCannotBeBothTruee(t *testing.T) {
 	auth, err := NewPasswordlessAuth(ConfigPasswordless{
-		Endpoint:                "/auth",
-		UrlRedirectOnSuccess:    "/user",
-		FuncTemporaryKeyGet:     func(key string) (value string, err error) { return "", nil },
-		FuncTemporaryKeySet:     func(key, value string, expiresSeconds int) (err error) { return nil },
-		FuncUserFindByAuthToken: func(sessionID string, options UserAuthOptions) (userID string, err error) { return "", nil },
-		FuncUserFindByEmail:     func(email string, options UserAuthOptions) (userID string, err error) { return "", nil },
-		FuncUserLogout:          func(userID string, options UserAuthOptions) (err error) { return nil },
-		FuncUserStoreAuthToken:  func(sessionID, userID string, options UserAuthOptions) error { return nil },
-		FuncEmailSend:           func(email, emailSubject, emailBody string) (err error) { return nil },
-		UseCookies:              true,
-		UseLocalStorage:         false,
+		Endpoint:             "/auth",
+		UrlRedirectOnSuccess: "/user",
+		FuncTemporaryKeyGet:  func(key string) (value string, err error) { return "", nil },
+		FuncTemporaryKeySet:  func(key, value string, expiresSeconds int) (err error) { return nil },
+		FuncUserFindByAuthToken: func(ctx context.Context, sessionID string, options UserAuthOptions) (userID string, err error) {
+			return "", nil
+		},
+		FuncUserFindByEmail: func(ctx context.Context, email string, options UserAuthOptions) (userID string, err error) {
+			return "", nil
+		},
+		FuncUserLogout:         func(ctx context.Context, userID string, options UserAuthOptions) (err error) { return nil },
+		FuncUserStoreAuthToken: func(ctx context.Context, sessionID, userID string, options UserAuthOptions) error { return nil },
+		FuncEmailSend:          func(ctx context.Context, email, emailSubject, emailBody string) (err error) { return nil },
+		UseCookies:             true,
+		UseLocalStorage:        false,
 	})
 
 	if err != nil {

--- a/new_username_and_password_auth.go
+++ b/new_username_and_password_auth.go
@@ -1,6 +1,7 @@
 package auth
 
 import (
+	"context"
 	"errors"
 	"net/http"
 	"time"
@@ -90,12 +91,17 @@ func NewUsernameAndPasswordAuth(config ConfigUsernameAndPassword) (*Auth, error)
 
 	// If no user defined email template is set, use default
 	if auth.funcEmailTemplatePasswordRestore == nil {
-		auth.funcEmailTemplatePasswordRestore = emailTemplatePasswordChange
+		auth.funcEmailTemplatePasswordRestore = func(ctx context.Context, userID string, passwordRestoreLink string, options UserAuthOptions) string {
+			// userID here is effectively the name/email for the template
+			return emailTemplatePasswordChange(userID, passwordRestoreLink, options)
+		}
 	}
 
 	// If no user defined email template is set, use default
 	if auth.funcEmailTemplateRegisterCode == nil {
-		auth.funcEmailTemplateRegisterCode = emailRegisterCodeTemplate
+		auth.funcEmailTemplateRegisterCode = func(ctx context.Context, email string, code string, options UserAuthOptions) string {
+			return emailRegisterCodeTemplate(email, code, options)
+		}
 	}
 
 	// Initialize rate limiting

--- a/new_username_and_password_auth_test.go
+++ b/new_username_and_password_auth_test.go
@@ -1,6 +1,7 @@
 package auth
 
 import (
+	"context"
 	"testing"
 )
 
@@ -70,11 +71,13 @@ func TestNewUsernameAndPasswordAuth_FuncUserFindByAuthTokenIsRequired(t *testing
 
 func TestNewUsernameAndPasswordAuth_FuncUserFindByUsernameIsRequired(t *testing.T) {
 	_, err := NewUsernameAndPasswordAuth(ConfigUsernameAndPassword{
-		Endpoint:                "/auth",
-		UrlRedirectOnSuccess:    "/user",
-		FuncTemporaryKeyGet:     func(key string) (value string, err error) { return "", nil },
-		FuncTemporaryKeySet:     func(key, value string, expiresSeconds int) (err error) { return nil },
-		FuncUserFindByAuthToken: func(sessionID string, options UserAuthOptions) (userID string, err error) { return "", nil },
+		Endpoint:             "/auth",
+		UrlRedirectOnSuccess: "/user",
+		FuncTemporaryKeyGet:  func(key string) (value string, err error) { return "", nil },
+		FuncTemporaryKeySet:  func(key, value string, expiresSeconds int) (err error) { return nil },
+		FuncUserFindByAuthToken: func(ctx context.Context, sessionID string, options UserAuthOptions) (userID string, err error) {
+			return "", nil
+		},
 	})
 	if err == nil {
 		t.Fatal("Error SHOULD NOT BE NULL")
@@ -86,12 +89,14 @@ func TestNewUsernameAndPasswordAuth_FuncUserFindByUsernameIsRequired(t *testing.
 
 func TestNewUsernameAndPasswordAuth_FuncUserLoginIsRequired(t *testing.T) {
 	_, err := NewUsernameAndPasswordAuth(ConfigUsernameAndPassword{
-		Endpoint:                "/auth",
-		UrlRedirectOnSuccess:    "/user",
-		FuncTemporaryKeyGet:     func(key string) (value string, err error) { return "", nil },
-		FuncTemporaryKeySet:     func(key, value string, expiresSeconds int) (err error) { return nil },
-		FuncUserFindByAuthToken: func(sessionID string, options UserAuthOptions) (userID string, err error) { return "", nil },
-		FuncUserFindByUsername: func(username, firstName, lastName string, options UserAuthOptions) (userID string, err error) {
+		Endpoint:             "/auth",
+		UrlRedirectOnSuccess: "/user",
+		FuncTemporaryKeyGet:  func(key string) (value string, err error) { return "", nil },
+		FuncTemporaryKeySet:  func(key, value string, expiresSeconds int) (err error) { return nil },
+		FuncUserFindByAuthToken: func(ctx context.Context, sessionID string, options UserAuthOptions) (userID string, err error) {
+			return "", nil
+		},
+		FuncUserFindByUsername: func(ctx context.Context, username, firstName, lastName string, options UserAuthOptions) (userID string, err error) {
 			return "", nil
 		},
 	})
@@ -105,15 +110,19 @@ func TestNewUsernameAndPasswordAuth_FuncUserLoginIsRequired(t *testing.T) {
 
 func TestNewUsernameAndPasswordAuth_FuncUserLogoutIsRequired(t *testing.T) {
 	_, err := NewUsernameAndPasswordAuth(ConfigUsernameAndPassword{
-		Endpoint:                "/auth",
-		UrlRedirectOnSuccess:    "/user",
-		FuncTemporaryKeyGet:     func(key string) (value string, err error) { return "", nil },
-		FuncTemporaryKeySet:     func(key, value string, expiresSeconds int) (err error) { return nil },
-		FuncUserFindByAuthToken: func(sessionID string, options UserAuthOptions) (userID string, err error) { return "", nil },
-		FuncUserFindByUsername: func(username, firstName, lastName string, options UserAuthOptions) (userID string, err error) {
+		Endpoint:             "/auth",
+		UrlRedirectOnSuccess: "/user",
+		FuncTemporaryKeyGet:  func(key string) (value string, err error) { return "", nil },
+		FuncTemporaryKeySet:  func(key, value string, expiresSeconds int) (err error) { return nil },
+		FuncUserFindByAuthToken: func(ctx context.Context, sessionID string, options UserAuthOptions) (userID string, err error) {
 			return "", nil
 		},
-		FuncUserLogin: func(username, password string, options UserAuthOptions) (userID string, err error) { return "", nil },
+		FuncUserFindByUsername: func(ctx context.Context, username, firstName, lastName string, options UserAuthOptions) (userID string, err error) {
+			return "", nil
+		},
+		FuncUserLogin: func(ctx context.Context, username, password string, options UserAuthOptions) (userID string, err error) {
+			return "", nil
+		},
 	})
 	if err == nil {
 		t.Fatal("Error SHOULD NOT BE NULL")
@@ -125,16 +134,20 @@ func TestNewUsernameAndPasswordAuth_FuncUserLogoutIsRequired(t *testing.T) {
 
 func TestNewUsernameAndPasswordAuth_FuncUserStoreTokenFuncUserStoreTokenIsRequired(t *testing.T) {
 	_, err := NewUsernameAndPasswordAuth(ConfigUsernameAndPassword{
-		Endpoint:                "/auth",
-		UrlRedirectOnSuccess:    "/user",
-		FuncTemporaryKeyGet:     func(key string) (value string, err error) { return "", nil },
-		FuncTemporaryKeySet:     func(key, value string, expiresSeconds int) (err error) { return nil },
-		FuncUserFindByAuthToken: func(sessionID string, options UserAuthOptions) (userID string, err error) { return "", nil },
-		FuncUserFindByUsername: func(username, firstName, lastName string, options UserAuthOptions) (userID string, err error) {
+		Endpoint:             "/auth",
+		UrlRedirectOnSuccess: "/user",
+		FuncTemporaryKeyGet:  func(key string) (value string, err error) { return "", nil },
+		FuncTemporaryKeySet:  func(key, value string, expiresSeconds int) (err error) { return nil },
+		FuncUserFindByAuthToken: func(ctx context.Context, sessionID string, options UserAuthOptions) (userID string, err error) {
 			return "", nil
 		},
-		FuncUserLogin:  func(username, password string, options UserAuthOptions) (userID string, err error) { return "", nil },
-		FuncUserLogout: func(userID string, options UserAuthOptions) (err error) { return nil },
+		FuncUserFindByUsername: func(ctx context.Context, username, firstName, lastName string, options UserAuthOptions) (userID string, err error) {
+			return "", nil
+		},
+		FuncUserLogin: func(ctx context.Context, username, password string, options UserAuthOptions) (userID string, err error) {
+			return "", nil
+		},
+		FuncUserLogout: func(ctx context.Context, userID string, options UserAuthOptions) (err error) { return nil },
 	})
 	if err == nil {
 		t.Fatal("Error SHOULD NOT BE NULL")
@@ -146,17 +159,21 @@ func TestNewUsernameAndPasswordAuth_FuncUserStoreTokenFuncUserStoreTokenIsRequir
 
 func TestNewUsernameAndPasswordAuth_FuncEmailSendIsRequired(t *testing.T) {
 	_, err := NewUsernameAndPasswordAuth(ConfigUsernameAndPassword{
-		Endpoint:                "/auth",
-		UrlRedirectOnSuccess:    "/user",
-		FuncTemporaryKeyGet:     func(key string) (value string, err error) { return "", nil },
-		FuncTemporaryKeySet:     func(key, value string, expiresSeconds int) (err error) { return nil },
-		FuncUserFindByAuthToken: func(sessionID string, options UserAuthOptions) (userID string, err error) { return "", nil },
-		FuncUserStoreAuthToken:  func(sessionID, userID string, options UserAuthOptions) error { return nil },
-		FuncUserFindByUsername: func(username, firstName, lastName string, options UserAuthOptions) (userID string, err error) {
+		Endpoint:             "/auth",
+		UrlRedirectOnSuccess: "/user",
+		FuncTemporaryKeyGet:  func(key string) (value string, err error) { return "", nil },
+		FuncTemporaryKeySet:  func(key, value string, expiresSeconds int) (err error) { return nil },
+		FuncUserFindByAuthToken: func(ctx context.Context, sessionID string, options UserAuthOptions) (userID string, err error) {
 			return "", nil
 		},
-		FuncUserLogin:  func(username, password string, options UserAuthOptions) (userID string, err error) { return "", nil },
-		FuncUserLogout: func(userID string, options UserAuthOptions) (err error) { return nil },
+		FuncUserStoreAuthToken: func(ctx context.Context, token, userID string, options UserAuthOptions) error { return nil },
+		FuncUserFindByUsername: func(ctx context.Context, username, firstName, lastName string, options UserAuthOptions) (userID string, err error) {
+			return "", nil
+		},
+		FuncUserLogin: func(ctx context.Context, username, password string, options UserAuthOptions) (userID string, err error) {
+			return "", nil
+		},
+		FuncUserLogout: func(ctx context.Context, userID string, options UserAuthOptions) (err error) { return nil },
 	})
 	if err == nil {
 		t.Fatal("Error SHOULD NOT BE NULL")
@@ -168,18 +185,22 @@ func TestNewUsernameAndPasswordAuth_FuncEmailSendIsRequired(t *testing.T) {
 
 func TestNewUsernameAndPasswordAuth_UseCookiesAndLocalStorageCannotBeBothFalse(t *testing.T) {
 	_, err := NewUsernameAndPasswordAuth(ConfigUsernameAndPassword{
-		Endpoint:                "/auth",
-		UrlRedirectOnSuccess:    "/user",
-		FuncTemporaryKeyGet:     func(key string) (value string, err error) { return "", nil },
-		FuncTemporaryKeySet:     func(key, value string, expiresSeconds int) (err error) { return nil },
-		FuncUserFindByAuthToken: func(sessionID string, options UserAuthOptions) (userID string, err error) { return "", nil },
-		FuncUserFindByUsername: func(username, firstName, lastName string, options UserAuthOptions) (userID string, err error) {
+		Endpoint:             "/auth",
+		UrlRedirectOnSuccess: "/user",
+		FuncTemporaryKeyGet:  func(key string) (value string, err error) { return "", nil },
+		FuncTemporaryKeySet:  func(key, value string, expiresSeconds int) (err error) { return nil },
+		FuncUserFindByAuthToken: func(ctx context.Context, sessionID string, options UserAuthOptions) (userID string, err error) {
 			return "", nil
 		},
-		FuncUserLogin:          func(username, password string, options UserAuthOptions) (userID string, err error) { return "", nil },
-		FuncUserLogout:         func(userID string, options UserAuthOptions) (err error) { return nil },
-		FuncUserStoreAuthToken: func(sessionID, userID string, options UserAuthOptions) error { return nil },
-		FuncEmailSend:          func(email, emailSubject, emailBody string) (err error) { return nil },
+		FuncUserFindByUsername: func(ctx context.Context, username, firstName, lastName string, options UserAuthOptions) (userID string, err error) {
+			return "", nil
+		},
+		FuncUserLogin: func(ctx context.Context, username, password string, options UserAuthOptions) (userID string, err error) {
+			return "", nil
+		},
+		FuncUserLogout:         func(ctx context.Context, userID string, options UserAuthOptions) (err error) { return nil },
+		FuncUserStoreAuthToken: func(ctx context.Context, token, userID string, options UserAuthOptions) error { return nil },
+		FuncEmailSend:          func(ctx context.Context, email, emailSubject, emailBody string) (err error) { return nil },
 	})
 	if err == nil {
 		t.Fatal("Error SHOULD NOT BE NULL")
@@ -191,18 +212,22 @@ func TestNewUsernameAndPasswordAuth_UseCookiesAndLocalStorageCannotBeBothFalse(t
 
 func TestNewUsernameAndPasswordAuth_UseCookiesAndLocalStorageCannotBeBothTrue(t *testing.T) {
 	_, err := NewUsernameAndPasswordAuth(ConfigUsernameAndPassword{
-		Endpoint:                "/auth",
-		UrlRedirectOnSuccess:    "/user",
-		FuncTemporaryKeyGet:     func(key string) (value string, err error) { return "", nil },
-		FuncTemporaryKeySet:     func(key, value string, expiresSeconds int) (err error) { return nil },
-		FuncUserFindByAuthToken: func(sessionID string, options UserAuthOptions) (userID string, err error) { return "", nil },
-		FuncUserLogout:          func(userID string, options UserAuthOptions) (err error) { return nil },
-		FuncUserStoreAuthToken:  func(sessionID, userID string, options UserAuthOptions) error { return nil },
-		FuncEmailSend:           func(email, emailSubject, emailBody string) (err error) { return nil },
-		FuncUserFindByUsername: func(username, firstName, lastName string, options UserAuthOptions) (userID string, err error) {
+		Endpoint:             "/auth",
+		UrlRedirectOnSuccess: "/user",
+		FuncTemporaryKeyGet:  func(key string) (value string, err error) { return "", nil },
+		FuncTemporaryKeySet:  func(key, value string, expiresSeconds int) (err error) { return nil },
+		FuncUserFindByAuthToken: func(ctx context.Context, sessionID string, options UserAuthOptions) (userID string, err error) {
 			return "", nil
 		},
-		FuncUserLogin:   func(username, password string, options UserAuthOptions) (userID string, err error) { return "", nil },
+		FuncUserLogout:         func(ctx context.Context, userID string, options UserAuthOptions) (err error) { return nil },
+		FuncUserStoreAuthToken: func(ctx context.Context, token, userID string, options UserAuthOptions) error { return nil },
+		FuncEmailSend:          func(ctx context.Context, email, emailSubject, emailBody string) (err error) { return nil },
+		FuncUserFindByUsername: func(ctx context.Context, username, firstName, lastName string, options UserAuthOptions) (userID string, err error) {
+			return "", nil
+		},
+		FuncUserLogin: func(ctx context.Context, username, password string, options UserAuthOptions) (userID string, err error) {
+			return "", nil
+		},
 		UseCookies:      true,
 		UseLocalStorage: true,
 	})
@@ -216,18 +241,22 @@ func TestNewUsernameAndPasswordAuth_UseCookiesAndLocalStorageCannotBeBothTrue(t 
 
 func TestNewUsernameAndPasswordAuth_UseCookiesAndLocalStorageCannotBeBothTruee(t *testing.T) {
 	auth, err := NewUsernameAndPasswordAuth(ConfigUsernameAndPassword{
-		Endpoint:                "/auth",
-		UrlRedirectOnSuccess:    "/user",
-		FuncTemporaryKeyGet:     func(key string) (value string, err error) { return "", nil },
-		FuncTemporaryKeySet:     func(key, value string, expiresSeconds int) (err error) { return nil },
-		FuncUserFindByAuthToken: func(sessionID string, options UserAuthOptions) (userID string, err error) { return "", nil },
-		FuncUserLogout:          func(userID string, options UserAuthOptions) (err error) { return nil },
-		FuncUserStoreAuthToken:  func(sessionID, userID string, options UserAuthOptions) error { return nil },
-		FuncEmailSend:           func(email, emailSubject, emailBody string) (err error) { return nil },
-		FuncUserFindByUsername: func(username, firstName, lastName string, options UserAuthOptions) (userID string, err error) {
+		Endpoint:             "/auth",
+		UrlRedirectOnSuccess: "/user",
+		FuncTemporaryKeyGet:  func(key string) (value string, err error) { return "", nil },
+		FuncTemporaryKeySet:  func(key, value string, expiresSeconds int) (err error) { return nil },
+		FuncUserFindByAuthToken: func(ctx context.Context, sessionID string, options UserAuthOptions) (userID string, err error) {
 			return "", nil
 		},
-		FuncUserLogin:   func(username, password string, options UserAuthOptions) (userID string, err error) { return "", nil },
+		FuncUserLogout:         func(ctx context.Context, userID string, options UserAuthOptions) (err error) { return nil },
+		FuncUserStoreAuthToken: func(ctx context.Context, sessionID, userID string, options UserAuthOptions) error { return nil },
+		FuncEmailSend:          func(ctx context.Context, email, emailSubject, emailBody string) (err error) { return nil },
+		FuncUserFindByUsername: func(ctx context.Context, username, firstName, lastName string, options UserAuthOptions) (userID string, err error) {
+			return "", nil
+		},
+		FuncUserLogin: func(ctx context.Context, username, password string, options UserAuthOptions) (userID string, err error) {
+			return "", nil
+		},
 		UseCookies:      true,
 		UseLocalStorage: false,
 	})
@@ -243,18 +272,22 @@ func TestNewUsernameAndPasswordAuth_UseCookiesAndLocalStorageCannotBeBothTruee(t
 
 func TestNewUsernameAndPasswordAuth_CSRFSecretRequiredWhenEnabled(t *testing.T) {
 	_, err := NewUsernameAndPasswordAuth(ConfigUsernameAndPassword{
-		Endpoint:                "/auth",
-		UrlRedirectOnSuccess:    "/user",
-		FuncTemporaryKeyGet:     func(key string) (value string, err error) { return "", nil },
-		FuncTemporaryKeySet:     func(key, value string, expiresSeconds int) (err error) { return nil },
-		FuncUserFindByAuthToken: func(sessionID string, options UserAuthOptions) (userID string, err error) { return "", nil },
-		FuncUserFindByUsername: func(username, firstName, lastName string, options UserAuthOptions) (userID string, err error) {
+		Endpoint:             "/auth",
+		UrlRedirectOnSuccess: "/user",
+		FuncTemporaryKeyGet:  func(key string) (value string, err error) { return "", nil },
+		FuncTemporaryKeySet:  func(key, value string, expiresSeconds int) (err error) { return nil },
+		FuncUserFindByAuthToken: func(ctx context.Context, sessionID string, options UserAuthOptions) (userID string, err error) {
 			return "", nil
 		},
-		FuncUserLogin:          func(username, password string, options UserAuthOptions) (userID string, err error) { return "", nil },
-		FuncUserLogout:         func(userID string, options UserAuthOptions) (err error) { return nil },
-		FuncUserStoreAuthToken: func(sessionID, userID string, options UserAuthOptions) error { return nil },
-		FuncEmailSend:          func(email, emailSubject, emailBody string) (err error) { return nil },
+		FuncUserFindByUsername: func(ctx context.Context, username, firstName, lastName string, options UserAuthOptions) (userID string, err error) {
+			return "", nil
+		},
+		FuncUserLogin: func(ctx context.Context, username, password string, options UserAuthOptions) (userID string, err error) {
+			return "", nil
+		},
+		FuncUserLogout:         func(ctx context.Context, userID string, options UserAuthOptions) (err error) { return nil },
+		FuncUserStoreAuthToken: func(ctx context.Context, sessionID, userID string, options UserAuthOptions) error { return nil },
+		FuncEmailSend:          func(ctx context.Context, email, emailSubject, emailBody string) (err error) { return nil },
 		UseCookies:             true,
 		UseLocalStorage:        false,
 		EnableCSRFProtection:   true,
@@ -269,18 +302,22 @@ func TestNewUsernameAndPasswordAuth_CSRFSecretRequiredWhenEnabled(t *testing.T) 
 
 func TestNewUsernameAndPasswordAuth_CSRFEnabledWithSecretSucceeds(t *testing.T) {
 	auth, err := NewUsernameAndPasswordAuth(ConfigUsernameAndPassword{
-		Endpoint:                "/auth",
-		UrlRedirectOnSuccess:    "/user",
-		FuncTemporaryKeyGet:     func(key string) (value string, err error) { return "", nil },
-		FuncTemporaryKeySet:     func(key, value string, expiresSeconds int) (err error) { return nil },
-		FuncUserFindByAuthToken: func(sessionID string, options UserAuthOptions) (userID string, err error) { return "", nil },
-		FuncUserFindByUsername: func(username, firstName, lastName string, options UserAuthOptions) (userID string, err error) {
+		Endpoint:             "/auth",
+		UrlRedirectOnSuccess: "/user",
+		FuncTemporaryKeyGet:  func(key string) (value string, err error) { return "", nil },
+		FuncTemporaryKeySet:  func(key, value string, expiresSeconds int) (err error) { return nil },
+		FuncUserFindByAuthToken: func(ctx context.Context, sessionID string, options UserAuthOptions) (userID string, err error) {
 			return "", nil
 		},
-		FuncUserLogin:          func(username, password string, options UserAuthOptions) (userID string, err error) { return "", nil },
-		FuncUserLogout:         func(userID string, options UserAuthOptions) (err error) { return nil },
-		FuncUserStoreAuthToken: func(sessionID, userID string, options UserAuthOptions) error { return nil },
-		FuncEmailSend:          func(email, emailSubject, emailBody string) (err error) { return nil },
+		FuncUserFindByUsername: func(ctx context.Context, username, firstName, lastName string, options UserAuthOptions) (userID string, err error) {
+			return "", nil
+		},
+		FuncUserLogin: func(ctx context.Context, username, password string, options UserAuthOptions) (userID string, err error) {
+			return "", nil
+		},
+		FuncUserLogout:         func(ctx context.Context, userID string, options UserAuthOptions) (err error) { return nil },
+		FuncUserStoreAuthToken: func(ctx context.Context, sessionID, userID string, options UserAuthOptions) error { return nil },
+		FuncEmailSend:          func(ctx context.Context, email, emailSubject, emailBody string) (err error) { return nil },
 		UseCookies:             true,
 		UseLocalStorage:        false,
 		EnableCSRFProtection:   true,

--- a/register_with_username_and_password.go
+++ b/register_with_username_and_password.go
@@ -1,6 +1,7 @@
 package auth
 
 import (
+	"context"
 	"encoding/json"
 	"log"
 	"net/mail"
@@ -15,7 +16,7 @@ type RegisterUsernameAndPasswordResponse struct {
 	Token          string
 }
 
-func (a Auth) RegisterWithUsernameAndPassword(email string, password string, firstName string, lastName string, options UserAuthOptions) (response RegisterUsernameAndPasswordResponse) {
+func (a Auth) RegisterWithUsernameAndPassword(ctx context.Context, email string, password string, firstName string, lastName string, options UserAuthOptions) (response RegisterUsernameAndPasswordResponse) {
 	if firstName == "" {
 		response.ErrorMessage = "First name is required field"
 		return response
@@ -47,7 +48,7 @@ func (a Auth) RegisterWithUsernameAndPassword(email string, password string, fir
 	}
 
 	if !a.enableVerification {
-		err := a.funcUserRegister(email, password, firstName, lastName, options)
+		err := a.funcUserRegister(ctx, email, password, firstName, lastName, options)
 
 		if err != nil {
 			response.ErrorMessage = "registration failed. " + err.Error()
@@ -86,9 +87,9 @@ func (a Auth) RegisterWithUsernameAndPassword(email string, password string, fir
 		return response
 	}
 
-	emailContent := a.funcEmailTemplateRegisterCode(email, verificationCode, options)
+	emailContent := a.funcEmailTemplateRegisterCode(ctx, email, verificationCode, options)
 
-	errEmailSent := a.funcEmailSend(email, "Registration Code", emailContent)
+	errEmailSent := a.funcEmailSend(ctx, email, "Registration Code", emailContent)
 
 	if errEmailSent != nil {
 		log.Println(errEmailSent)

--- a/register_with_username_and_password_test.go
+++ b/register_with_username_and_password_test.go
@@ -1,6 +1,7 @@
 package auth
 
 import (
+	"context"
 	"errors"
 	"testing"
 )
@@ -12,7 +13,7 @@ func newAuthForRegisterTests() *Auth {
 func TestRegisterWithUsernameAndPassword_RequiresFirstName(t *testing.T) {
 	authInstance := newAuthForRegisterTests()
 
-	resp := authInstance.RegisterWithUsernameAndPassword("test@test.com", "password", "", "Doe", UserAuthOptions{})
+	resp := authInstance.RegisterWithUsernameAndPassword(context.Background(), "test@test.com", "password", "", "Doe", UserAuthOptions{})
 
 	expected := "First name is required field"
 	if resp.ErrorMessage != expected {
@@ -23,7 +24,7 @@ func TestRegisterWithUsernameAndPassword_RequiresFirstName(t *testing.T) {
 func TestRegisterWithUsernameAndPassword_RequiresLastName(t *testing.T) {
 	authInstance := newAuthForRegisterTests()
 
-	resp := authInstance.RegisterWithUsernameAndPassword("test@test.com", "password", "John", "", UserAuthOptions{})
+	resp := authInstance.RegisterWithUsernameAndPassword(context.Background(), "test@test.com", "password", "John", "", UserAuthOptions{})
 
 	expected := "Last name is required field"
 	if resp.ErrorMessage != expected {
@@ -34,7 +35,7 @@ func TestRegisterWithUsernameAndPassword_RequiresLastName(t *testing.T) {
 func TestRegisterWithUsernameAndPassword_RequiresEmail(t *testing.T) {
 	authInstance := newAuthForRegisterTests()
 
-	resp := authInstance.RegisterWithUsernameAndPassword("", "password", "John", "Doe", UserAuthOptions{})
+	resp := authInstance.RegisterWithUsernameAndPassword(context.Background(), "", "password", "John", "Doe", UserAuthOptions{})
 
 	expected := "Email is required field"
 	if resp.ErrorMessage != expected {
@@ -45,7 +46,7 @@ func TestRegisterWithUsernameAndPassword_RequiresEmail(t *testing.T) {
 func TestRegisterWithUsernameAndPassword_RequiresPassword(t *testing.T) {
 	authInstance := newAuthForRegisterTests()
 
-	resp := authInstance.RegisterWithUsernameAndPassword("test@test.com", "", "John", "Doe", UserAuthOptions{})
+	resp := authInstance.RegisterWithUsernameAndPassword(context.Background(), "test@test.com", "", "John", "Doe", UserAuthOptions{})
 
 	expected := "Password is required field"
 	if resp.ErrorMessage != expected {
@@ -56,7 +57,7 @@ func TestRegisterWithUsernameAndPassword_RequiresPassword(t *testing.T) {
 func TestRegisterWithUsernameAndPassword_InvalidEmail(t *testing.T) {
 	authInstance := newAuthForRegisterTests()
 
-	resp := authInstance.RegisterWithUsernameAndPassword("invalid-email", "password", "John", "Doe", UserAuthOptions{})
+	resp := authInstance.RegisterWithUsernameAndPassword(context.Background(), "invalid-email", "password", "John", "Doe", UserAuthOptions{})
 
 	expected := "This is not a valid email: invalid-email"
 	if resp.ErrorMessage != expected {
@@ -67,7 +68,7 @@ func TestRegisterWithUsernameAndPassword_InvalidEmail(t *testing.T) {
 func TestRegisterWithUsernameAndPassword_FuncUserRegisterNotDefined(t *testing.T) {
 	authInstance := newAuthForRegisterTests()
 
-	resp := authInstance.RegisterWithUsernameAndPassword("test@test.com", "password", "John", "Doe", UserAuthOptions{})
+	resp := authInstance.RegisterWithUsernameAndPassword(context.Background(), "test@test.com", "password", "John", "Doe", UserAuthOptions{})
 
 	expected := "registration failed. FuncUserRegister function not defined"
 	if resp.ErrorMessage != expected {
@@ -79,11 +80,11 @@ func TestRegisterWithUsernameAndPassword_RegistrationFailed_NoVerification(t *te
 	authInstance := newAuthForRegisterTests()
 
 	// enableVerification is false by default
-	authInstance.funcUserRegister = func(username string, password string, firstName string, lastName string, options UserAuthOptions) error {
+	authInstance.funcUserRegister = func(ctx context.Context, username string, password string, firstName string, lastName string, options UserAuthOptions) error {
 		return errors.New("db error")
 	}
 
-	resp := authInstance.RegisterWithUsernameAndPassword("test@test.com", "password", "John", "Doe", UserAuthOptions{})
+	resp := authInstance.RegisterWithUsernameAndPassword(context.Background(), "test@test.com", "password", "John", "Doe", UserAuthOptions{})
 
 	expected := "registration failed. db error"
 	if resp.ErrorMessage != expected {
@@ -94,11 +95,11 @@ func TestRegisterWithUsernameAndPassword_RegistrationFailed_NoVerification(t *te
 func TestRegisterWithUsernameAndPassword_RegistrationSuccess_NoVerification(t *testing.T) {
 	authInstance := newAuthForRegisterTests()
 
-	authInstance.funcUserRegister = func(username string, password string, firstName string, lastName string, options UserAuthOptions) error {
+	authInstance.funcUserRegister = func(ctx context.Context, username string, password string, firstName string, lastName string, options UserAuthOptions) error {
 		return nil
 	}
 
-	resp := authInstance.RegisterWithUsernameAndPassword("test@test.com", "password", "John", "Doe", UserAuthOptions{})
+	resp := authInstance.RegisterWithUsernameAndPassword(context.Background(), "test@test.com", "password", "John", "Doe", UserAuthOptions{})
 
 	if resp.ErrorMessage != "" {
 		t.Fatalf("expected no error, got %q", resp.ErrorMessage)
@@ -115,7 +116,7 @@ func TestRegisterWithUsernameAndPassword_VerificationEnabled_TokenStoreError(t *
 
 	authInstance.enableVerification = true
 	// funcUserRegister must be defined even if not used, otherwise earlier check fails
-	authInstance.funcUserRegister = func(username string, password string, firstName string, lastName string, options UserAuthOptions) error {
+	authInstance.funcUserRegister = func(ctx context.Context, username string, password string, firstName string, lastName string, options UserAuthOptions) error {
 		return nil
 	}
 
@@ -125,15 +126,15 @@ func TestRegisterWithUsernameAndPassword_VerificationEnabled_TokenStoreError(t *
 	}
 
 	// Provide minimal email template and send functions
-	authInstance.funcEmailTemplateRegisterCode = func(email string, code string, options UserAuthOptions) string {
+	authInstance.funcEmailTemplateRegisterCode = func(ctx context.Context, email string, code string, options UserAuthOptions) string {
 		return "body"
 	}
 	// Email send not reached in this test
-	authInstance.funcEmailSend = func(userID string, emailSubject string, emailBody string) error {
+	authInstance.funcEmailSend = func(ctx context.Context, userID string, emailSubject string, emailBody string) error {
 		return nil
 	}
 
-	resp := authInstance.RegisterWithUsernameAndPassword("test@test.com", "password", "John", "Doe", UserAuthOptions{})
+	resp := authInstance.RegisterWithUsernameAndPassword(context.Background(), "test@test.com", "password", "John", "Doe", UserAuthOptions{})
 
 	expected := "token store failed. db error"
 	if resp.ErrorMessage != expected {
@@ -145,7 +146,7 @@ func TestRegisterWithUsernameAndPassword_VerificationEnabled_EmailSendError(t *t
 	authInstance := newAuthForRegisterTests()
 
 	authInstance.enableVerification = true
-	authInstance.funcUserRegister = func(username string, password string, firstName string, lastName string, options UserAuthOptions) error {
+	authInstance.funcUserRegister = func(ctx context.Context, username string, password string, firstName string, lastName string, options UserAuthOptions) error {
 		return nil
 	}
 
@@ -153,15 +154,15 @@ func TestRegisterWithUsernameAndPassword_VerificationEnabled_EmailSendError(t *t
 		return nil
 	}
 
-	authInstance.funcEmailTemplateRegisterCode = func(email string, code string, options UserAuthOptions) string {
+	authInstance.funcEmailTemplateRegisterCode = func(ctx context.Context, email string, code string, options UserAuthOptions) string {
 		return "body"
 	}
 
-	authInstance.funcEmailSend = func(userID string, emailSubject string, emailBody string) error {
+	authInstance.funcEmailSend = func(ctx context.Context, userID string, emailSubject string, emailBody string) error {
 		return errors.New("smtp error")
 	}
 
-	resp := authInstance.RegisterWithUsernameAndPassword("test@test.com", "password", "John", "Doe", UserAuthOptions{})
+	resp := authInstance.RegisterWithUsernameAndPassword(context.Background(), "test@test.com", "password", "John", "Doe", UserAuthOptions{})
 
 	expected := "Registration code failed to be send. Please try again later"
 	if resp.ErrorMessage != expected {
@@ -173,7 +174,7 @@ func TestRegisterWithUsernameAndPassword_VerificationEnabled_Success(t *testing.
 	authInstance := newAuthForRegisterTests()
 
 	authInstance.enableVerification = true
-	authInstance.funcUserRegister = func(username string, password string, firstName string, lastName string, options UserAuthOptions) error {
+	authInstance.funcUserRegister = func(ctx context.Context, username string, password string, firstName string, lastName string, options UserAuthOptions) error {
 		return nil
 	}
 
@@ -181,15 +182,15 @@ func TestRegisterWithUsernameAndPassword_VerificationEnabled_Success(t *testing.
 		return nil
 	}
 
-	authInstance.funcEmailTemplateRegisterCode = func(email string, code string, options UserAuthOptions) string {
+	authInstance.funcEmailTemplateRegisterCode = func(ctx context.Context, email string, code string, options UserAuthOptions) string {
 		return "body"
 	}
 
-	authInstance.funcEmailSend = func(userID string, emailSubject string, emailBody string) error {
+	authInstance.funcEmailSend = func(ctx context.Context, userID string, emailSubject string, emailBody string) error {
 		return nil
 	}
 
-	resp := authInstance.RegisterWithUsernameAndPassword("test@test.com", "password", "John", "Doe", UserAuthOptions{})
+	resp := authInstance.RegisterWithUsernameAndPassword(context.Background(), "test@test.com", "password", "John", "Doe", UserAuthOptions{})
 
 	if resp.ErrorMessage != "" {
 		t.Fatalf("expected no error, got %q", resp.ErrorMessage)

--- a/testutils.go
+++ b/testutils.go
@@ -1,42 +1,54 @@
 package auth
 
+import "context"
+
 // testSetupUsernameAndPasswordAuth creates a new Auth for testing
 func testSetupUsernameAndPasswordAuth() (*Auth, error) {
 	endpoint := "http://localhost/auth"
 	return NewUsernameAndPasswordAuth(ConfigUsernameAndPassword{
-		Endpoint:                endpoint,
-		UrlRedirectOnSuccess:    "http://localhost/dashboard",
-		FuncTemporaryKeyGet:     func(key string) (value string, err error) { return "", nil },
-		FuncTemporaryKeySet:     func(key string, value string, expiresSeconds int) (err error) { return nil },
-		FuncUserFindByAuthToken: func(token string, options UserAuthOptions) (userID string, err error) { return "", nil },
-		FuncUserFindByUsername: func(username string, firstName string, lastName string, options UserAuthOptions) (userID string, err error) {
+		Endpoint:             endpoint,
+		UrlRedirectOnSuccess: "http://localhost/dashboard",
+		FuncTemporaryKeyGet:  func(key string) (value string, err error) { return "", nil },
+		FuncTemporaryKeySet:  func(key string, value string, expiresSeconds int) (err error) { return nil },
+		FuncUserFindByAuthToken: func(ctx context.Context, token string, options UserAuthOptions) (userID string, err error) {
 			return "", nil
 		},
-		FuncUserLogin: func(username string, password string, options UserAuthOptions) (userID string, err error) {
+		FuncUserFindByUsername: func(ctx context.Context, username string, firstName string, lastName string, options UserAuthOptions) (userID string, err error) {
 			return "", nil
 		},
-		FuncUserLogout: func(userID string, options UserAuthOptions) (err error) { return nil },
-		FuncUserStoreAuthToken: func(sessionID string, userID string, options UserAuthOptions) (err error) {
+		FuncUserLogin: func(ctx context.Context, username string, password string, options UserAuthOptions) (userID string, err error) {
+			return "", nil
+		},
+		FuncUserLogout: func(ctx context.Context, userID string, options UserAuthOptions) (err error) { return nil },
+		FuncUserStoreAuthToken: func(ctx context.Context, sessionID string, userID string, options UserAuthOptions) error {
 			return nil
 		},
-		FuncEmailSend: func(userID string, emailSubject string, emailBody string) (err error) { return nil },
-		UseCookies:    true,
+		FuncEmailSend: func(ctx context.Context, userID string, emailSubject string, emailBody string) (err error) {
+			return nil
+		},
+		UseCookies: true,
 	})
 }
 
-// testSetupUsernameAndPasswordAuth creates a new Auth for testing
+// testSetupPasswordlessAuth creates a new Auth for testing
 func testSetupPasswordlessAuth() (*Auth, error) {
 	endpoint := "http://localhost/auth"
 	return NewPasswordlessAuth(ConfigPasswordless{
-		Endpoint:                endpoint,
-		UrlRedirectOnSuccess:    "http://localhost/dashboard",
-		FuncTemporaryKeyGet:     func(key string) (value string, err error) { return "", nil },
-		FuncTemporaryKeySet:     func(key string, value string, expiresSeconds int) (err error) { return nil },
-		FuncUserFindByAuthToken: func(token string, options UserAuthOptions) (userID string, err error) { return "111", nil },
-		FuncUserFindByEmail:     func(email string, options UserAuthOptions) (userID string, err error) { return "111", nil },
-		FuncUserLogout:          func(userID string, options UserAuthOptions) (err error) { return nil },
-		FuncUserStoreAuthToken:  func(sessionID string, userID string, options UserAuthOptions) (err error) { return nil },
-		FuncEmailSend:           func(email string, emailSubject string, emailBody string) (err error) { return nil },
-		UseCookies:              true,
+		Endpoint:             endpoint,
+		UrlRedirectOnSuccess: "http://localhost/dashboard",
+		FuncTemporaryKeyGet:  func(key string) (value string, err error) { return "", nil },
+		FuncTemporaryKeySet:  func(key string, value string, expiresSeconds int) (err error) { return nil },
+		FuncUserFindByAuthToken: func(ctx context.Context, token string, options UserAuthOptions) (userID string, err error) {
+			return "111", nil
+		},
+		FuncUserFindByEmail: func(ctx context.Context, email string, options UserAuthOptions) (userID string, err error) {
+			return "111", nil
+		},
+		FuncUserLogout: func(ctx context.Context, userID string, options UserAuthOptions) (err error) { return nil },
+		FuncUserStoreAuthToken: func(ctx context.Context, sessionID string, userID string, options UserAuthOptions) error {
+			return nil
+		},
+		FuncEmailSend: func(ctx context.Context, email string, emailSubject string, emailBody string) (err error) { return nil },
+		UseCookies:    true,
 	})
 }

--- a/web_append_user_id_if_exists_middleware.go
+++ b/web_append_user_id_if_exists_middleware.go
@@ -23,7 +23,7 @@ func (a Auth) WebAppendUserIdIfExistsMiddleware(next http.Handler) http.Handler 
 		authToken := AuthTokenRetrieve(r, a.useCookies)
 
 		if authToken != "" {
-			userID, err := a.funcUserFindByAuthToken(authToken, UserAuthOptions{
+			userID, err := a.funcUserFindByAuthToken(r.Context(), authToken, UserAuthOptions{
 				UserIp:    req.GetIP(r),
 				UserAgent: r.UserAgent(),
 			})

--- a/web_append_user_id_if_exists_middleware_test.go
+++ b/web_append_user_id_if_exists_middleware_test.go
@@ -2,6 +2,7 @@ package auth
 
 import (
 	"bytes"
+	"context"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -13,18 +14,26 @@ func TestBlockRobotsMiddlewareShouldPassForHomeWithoutSlash(t *testing.T) {
 		UrlRedirectOnSuccess: "/user",
 		FuncTemporaryKeyGet:  func(key string) (value string, err error) { return "", nil },
 		FuncTemporaryKeySet:  func(key, value string, expiresSeconds int) (err error) { return nil },
-		FuncUserFindByAuthToken: func(sessionID string, options UserAuthOptions) (userID string, err error) {
+		FuncUserFindByAuthToken: func(ctx context.Context, sessionID string, options UserAuthOptions) (userID string, err error) {
 			if sessionID == "123456" {
 				return "234567", nil
 			}
 			return "", nil
 		},
-		FuncUserFindByEmail:    func(email string, options UserAuthOptions) (userID string, err error) { return "", nil },
-		FuncUserLogout:         func(userID string, options UserAuthOptions) (err error) { return nil },
-		FuncUserStoreAuthToken: func(sessionID, userID string, options UserAuthOptions) error { return nil },
-		FuncEmailSend:          func(email, emailSubject, emailBody string) (err error) { return nil },
-		UseCookies:             true,
-		UseLocalStorage:        false,
+		FuncUserFindByEmail: func(ctx context.Context, email string, options UserAuthOptions) (userID string, err error) {
+			return "", nil
+		},
+		FuncUserLogout: func(ctx context.Context, userID string, options UserAuthOptions) (err error) {
+			return nil
+		},
+		FuncUserStoreAuthToken: func(ctx context.Context, sessionID, userID string, options UserAuthOptions) error {
+			return nil
+		},
+		FuncEmailSend: func(ctx context.Context, email, emailSubject, emailBody string) (err error) {
+			return nil
+		},
+		UseCookies:      true,
+		UseLocalStorage: false,
 	})
 
 	if err != nil {

--- a/web_auth_or_redirect_middleware.go
+++ b/web_auth_or_redirect_middleware.go
@@ -25,7 +25,7 @@ func (a Auth) WebAuthOrRedirectMiddleware(next http.Handler) http.Handler {
 			return
 		}
 
-		userID, err := a.funcUserFindByAuthToken(authToken, UserAuthOptions{
+		userID, err := a.funcUserFindByAuthToken(r.Context(), authToken, UserAuthOptions{
 			UserIp:    req.GetIP(r),
 			UserAgent: r.UserAgent(),
 		})

--- a/web_auth_or_redirect_middleware_test.go
+++ b/web_auth_or_redirect_middleware_test.go
@@ -2,6 +2,7 @@ package auth
 
 import (
 	"bytes"
+	"context"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -44,7 +45,7 @@ func TestWebAuthOrRedirectMiddleware_InvalidToken_RedirectsToLogin(t *testing.T)
 	}
 
 	// Simulate an error in token lookup
-	authInstance.funcUserFindByAuthToken = func(sessionID string, options UserAuthOptions) (userID string, err error) {
+	authInstance.funcUserFindByAuthToken = func(ctx context.Context, token string, options UserAuthOptions) (userID string, err error) {
 		return "", http.ErrNoCookie
 	}
 
@@ -81,8 +82,8 @@ func TestWebAuthOrRedirectMiddleware_ValidToken_AppendsUserIDToContext(t *testin
 	}
 
 	// Valid token returns a userID
-	authInstance.funcUserFindByAuthToken = func(sessionID string, options UserAuthOptions) (userID string, err error) {
-		if sessionID == "123456" {
+	authInstance.funcUserFindByAuthToken = func(ctx context.Context, token string, options UserAuthOptions) (userID string, err error) {
+		if token == "123456" {
 			return "234567", nil
 		}
 		return "", nil


### PR DESCRIPTION
- Add ctx context.Context as first parameter to all user callback functions (FuncUserLogin, FuncUserFindByEmail, FuncUserFindByUsername, FuncUserFindByAuthToken, FuncUserStoreAuthToken, FuncUserLogout, FuncUserPasswordChange, FuncUserRegister, FuncEmailSend)
- Add ctx context.Context as first parameter to all email template functions (FuncEmailTemplateLoginCode, FuncEmailTemplateRegisterCode, FuncEmailTemplatePasswordRestore)